### PR TITLE
Setup esbuild build script

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ export default tseslint.config(
             "**/node_modules/**",
             "**/.turbo/**",
             "**/coverage/**",
+            "**/.coverage/**",
             "**/.yarn/**",
             "**/.pnp.*",
             "**/*.mjs",
@@ -46,6 +47,13 @@ export default tseslint.config(
                     varsIgnorePattern: "^_",
                     args: "after-used",
                     argsIgnorePattern: "^_",
+                },
+            ],
+            "@typescript-eslint/consistent-type-imports": [
+                "error",
+                {
+                    prefer: "type-imports",
+                    disallowTypeAnnotations: false,
                 },
             ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,7 @@ export default tseslint.config(
     {
         files: ["**/*.{test,spec}.{ts,tsx,js,jsx}"],
         rules: {
+            "@typescript-eslint/no-explicit-any": "off",
             "no-restricted-imports": [
                 "error",
                 {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "build": "turbo run build --cache-dir=.turbo",
         "test": "turbo run test --cache-dir=.turbo",
         "lint": "turbo run lint --cache-dir=.turbo",
+        "lint:fix": "turbo run lint:fix --cache-dir=.turbo",
         "typecheck": "turbo run typecheck --cache-dir=.turbo",
         "clean": "turbo run clean && rm -rf node_modules .turbo"
     },

--- a/packages/patchlogr-cli/esbuild.mjs
+++ b/packages/patchlogr-cli/esbuild.mjs
@@ -5,6 +5,8 @@ await build({
     entryPoints: [path.resolve("src/index.ts")],
     outfile: "dist/index.js",
     platform: "node",
+    bundle: true,
+    sourcemap: true,
     banner: {
         js: "#!/usr/bin/env node",
     },

--- a/packages/patchlogr-cli/package.json
+++ b/packages/patchlogr-cli/package.json
@@ -4,17 +4,23 @@
     "publishConfig": {
         "access": "public"
     },
+    "bin": {
+        "patchlogr": "./dist/index.js"
+    },
     "scripts": {
         "clean": "rm -rf dist",
         "typecheck": "tsc -p tsconfig.json --noEmit",
         "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
         "build:js": "node ./esbuild.mjs",
         "build": "yarn clean && yarn build:types && yarn build:js",
+        "preview": "node dist/index.js",
         "test": "vitest",
         "lint": "eslint ."
     },
     "dependencies": {
-        "@patchlogr/core": "workspace:*"
+        "@patchlogr/core": "workspace:*",
+        "@patchlogr/oas": "workspace:*",
+        "commander": "^14.0.2"
     },
     "devDependencies": {
         "@types/node": "24",

--- a/packages/patchlogr-cli/package.json
+++ b/packages/patchlogr-cli/package.json
@@ -15,7 +15,8 @@
         "build": "yarn clean && yarn build:types && yarn build:js",
         "preview": "node dist/index.js",
         "test": "vitest",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@patchlogr/core": "workspace:*",

--- a/packages/patchlogr-cli/src/cli.ts
+++ b/packages/patchlogr-cli/src/cli.ts
@@ -1,0 +1,37 @@
+import { Command } from "commander";
+
+export function createCLI() {
+    const program = new Command();
+
+    program
+        .name("patchlogr")
+        .version("0.0.0")
+        .description("PatchlogrCLI : changelogs from openapi specs");
+
+    program
+        .command("help")
+        .description("Display help information about patchlogr commands");
+
+    program
+        .command("canonicalize")
+        .argument("<api-docs>", "Path to the OpenAPI specification file")
+        .option("--canonicalize", "Canonicalize the OpenAPI specification")
+        .option(
+            "--skipValidation",
+            "Skip validation of the OpenAPI specification",
+        )
+        .option(
+            "-o, --output <file>",
+            "Write result to file instead of stdout (default: stdout)",
+        )
+        .action(async (apiDocs, options) => {
+            try {
+                console.log("[patchlogr] Processing:", apiDocs, options);
+            } catch (error) {
+                console.error("[patchlogr] Error:", (error as Error).message);
+                process.exitCode = 1;
+            }
+        });
+
+    return program;
+}

--- a/packages/patchlogr-cli/src/commands/runCanonicalize.ts
+++ b/packages/patchlogr-cli/src/commands/runCanonicalize.ts
@@ -1,0 +1,11 @@
+import { preprocessOASDocument } from "@patchlogr/oas";
+import { type OASStageOptions } from "@patchlogr/oas";
+
+export type RunCanonicalizeOptions = OASStageOptions;
+
+export async function runCanonicalize(
+    apiDocs: any,
+    options: RunCanonicalizeOptions,
+) {
+    preprocessOASDocument(apiDocs, { ...options });
+}

--- a/packages/patchlogr-cli/src/index.ts
+++ b/packages/patchlogr-cli/src/index.ts
@@ -1,0 +1,8 @@
+import { createCLI } from "./cli";
+
+const program = createCLI();
+
+program.parseAsync(process.argv).catch((error) => {
+    console.error("[patchlogr] Error:", error);
+    process.exitCode = 1;
+});

--- a/packages/patchlogr-core/package.json
+++ b/packages/patchlogr-core/package.json
@@ -22,7 +22,8 @@
         "build:js": "node ./esbuild.mjs",
         "build": "yarn clean && yarn build:types && yarn build:js",
         "test": "vitest",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",

--- a/packages/patchlogr-oas/esbuild.mjs
+++ b/packages/patchlogr-oas/esbuild.mjs
@@ -1,0 +1,16 @@
+import { build } from "esbuild";
+import pkg from "./package.json" with { type: "json" };
+
+await build({
+    entryPoints: ["src/index.ts"],
+    outdir: "dist",
+    bundle: true,
+    platform: "node",
+    target: ["node18", "node20", "node24"],
+    format: "esm",
+    sourcemap: true,
+    external: [
+        ...Object.keys(pkg.dependencies || {}),
+        ...Object.keys(pkg.peerDependencies || {}),
+    ],
+});

--- a/packages/patchlogr-oas/package.json
+++ b/packages/patchlogr-oas/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "clean": "rm -rf dist",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "test": "vitest",
         "typecheck": "tsc --noEmit",
         "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",

--- a/packages/patchlogr-oas/package.json
+++ b/packages/patchlogr-oas/package.json
@@ -5,12 +5,23 @@
         "access": "public"
     },
     "scripts": {
+        "clean": "rm -rf dist",
         "lint": "eslint .",
         "test": "vitest",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc --noEmit",
+        "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
+        "build:js": "node ./esbuild.mjs",
+        "build": "yarn clean && yarn build:types && yarn build:js"
+    },
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts"
+        }
     },
     "devDependencies": {
         "@types/node": "24",
+        "esbuild": "^0.27.2",
         "openapi-types": "^12.1.3",
         "vitest": "^4.0.16"
     },

--- a/packages/patchlogr-oas/src/__tests__/preprocessOASDocument.test.ts
+++ b/packages/patchlogr-oas/src/__tests__/preprocessOASDocument.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { preprocessOASDocument } from "../index";
-import { OpenAPIV2, OpenAPIV3 } from "openapi-types";
+import type { OpenAPIV2, OpenAPIV3 } from "openapi-types";
 
 const docV2: OpenAPIV2.Document = {
     swagger: "2.0",

--- a/packages/patchlogr-oas/src/canonicalize/__fixtures__/docV2.ts
+++ b/packages/patchlogr-oas/src/canonicalize/__fixtures__/docV2.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV2 } from "openapi-types";
+import type { OpenAPIV2 } from "openapi-types";
 
 export const docV2: OpenAPIV2.Document = {
     swagger: "2.0",

--- a/packages/patchlogr-oas/src/canonicalize/__fixtures__/docV3.ts
+++ b/packages/patchlogr-oas/src/canonicalize/__fixtures__/docV3.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV3 } from "openapi-types";
+import type { OpenAPIV3 } from "openapi-types";
 
 export const docV3: OpenAPIV3.Document = {
     openapi: "3.0.0",

--- a/packages/patchlogr-oas/src/canonicalize/__tests__/v3/canonicalizeOASV3.test.ts
+++ b/packages/patchlogr-oas/src/canonicalize/__tests__/v3/canonicalizeOASV3.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { CanonicalSchema } from "@patchlogr/types";
+import type { CanonicalSchema } from "@patchlogr/types";
 
 import {
     canonicalizeOASV3,

--- a/packages/patchlogr-oas/src/canonicalize/v2/index.ts
+++ b/packages/patchlogr-oas/src/canonicalize/v2/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     CanonicalOperation,
     CanonicalParam,
     CanonicalSpec,
@@ -9,7 +9,7 @@ import {
     CanonicalOperationDoc,
     CanonicalSecurityRequirement,
 } from "@patchlogr/types";
-import { OpenAPIV2 } from "openapi-types";
+import type { OpenAPIV2 } from "openapi-types";
 import { toCanonicalSchema } from "../../utils/toCanonicalSchema";
 
 const HTTP_METHODS = [

--- a/packages/patchlogr-oas/src/canonicalize/v3/index.ts
+++ b/packages/patchlogr-oas/src/canonicalize/v3/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     CanonicalOperation,
     CanonicalParam,
     CanonicalSpec,
@@ -9,7 +9,7 @@ import {
     CanonicalOperationDoc,
     CanonicalSecurityRequirement,
 } from "@patchlogr/types";
-import { OpenAPIV3 } from "openapi-types";
+import type { OpenAPIV3 } from "openapi-types";
 import { toCanonicalSchema } from "../../utils/toCanonicalSchema";
 
 const HTTP_METHODS = [

--- a/packages/patchlogr-oas/src/guards/parameterGuards.ts
+++ b/packages/patchlogr-oas/src/guards/parameterGuards.ts
@@ -1,4 +1,4 @@
-import { CanonicalParam } from "@patchlogr/types";
+import type { CanonicalParam } from "@patchlogr/types";
 
 export function isValidCanonicalParamIn(
     val: string,

--- a/packages/patchlogr-oas/src/guards/schemaGuards.ts
+++ b/packages/patchlogr-oas/src/guards/schemaGuards.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV2, OpenAPIV3 } from "openapi-types";
+import type { OpenAPIV2, OpenAPIV3 } from "openapi-types";
 
 export type OpenAPISchemaObject =
     | OpenAPIV2.SchemaObject

--- a/packages/patchlogr-oas/src/index.ts
+++ b/packages/patchlogr-oas/src/index.ts
@@ -1,24 +1,2 @@
-import { OpenAPI } from "openapi-types";
-import { PipelineExecutor } from "./pipeline/PipelineExecutor";
-import { OASValidationStage } from "./pipeline/OASValidationStage";
-import { OASCanonicalizeStage } from "./pipeline/OASCanonicalizeStage";
-import { OASBundleStage } from "./pipeline/OASBundleStage";
-import { OASStageContext, OASStageOptions } from "./pipeline/OASStageContext";
-import { OASDereferenceStage } from "./pipeline/OASDereferenceStage";
-
-export function preprocessOASDocument(
-    doc: OpenAPI.Document,
-    options: OASStageOptions = {},
-) {
-    const pipelineExecutor = new PipelineExecutor<OASStageContext>();
-
-    pipelineExecutor.add(new OASBundleStage());
-    pipelineExecutor.add(new OASValidationStage());
-    pipelineExecutor.add(new OASDereferenceStage());
-    pipelineExecutor.add(new OASCanonicalizeStage());
-
-    return pipelineExecutor.run({
-        source: doc,
-        options,
-    });
-}
+export { type OASStageOptions } from "./pipeline/OASStageContext";
+export { preprocessOASDocument } from "./preprocessOASDocument";

--- a/packages/patchlogr-oas/src/pipeline/OASBundleStage.ts
+++ b/packages/patchlogr-oas/src/pipeline/OASBundleStage.ts
@@ -1,6 +1,6 @@
 import SwaggerParser from "@apidevtools/swagger-parser";
-import { OASStageContext } from "./OASStageContext";
-import { PipelineStage } from "./PipelineExecutor";
+import type { OASStageContext } from "./OASStageContext";
+import type { PipelineStage } from "./PipelineExecutor";
 
 /**
  * 외부 $ref, schema 를 포함한 모든 문서를 합침

--- a/packages/patchlogr-oas/src/pipeline/OASCanonicalizeStage.ts
+++ b/packages/patchlogr-oas/src/pipeline/OASCanonicalizeStage.ts
@@ -1,6 +1,6 @@
-import { CanonicalSpec } from "@patchlogr/types";
-import { OASStageContext } from "./OASStageContext";
-import { PipelineStage } from "./PipelineExecutor";
+import type { CanonicalSpec } from "@patchlogr/types";
+import type { OASStageContext } from "./OASStageContext";
+import type { PipelineStage } from "./PipelineExecutor";
 import { canonicalizeOASV2 } from "../canonicalize/v2";
 import { canonicalizeOASV3 } from "../canonicalize/v3";
 import { isOpenAPIV2, isOpenAPIV3 } from "../utils/oasVersionUtils";

--- a/packages/patchlogr-oas/src/pipeline/OASDereferenceStage.ts
+++ b/packages/patchlogr-oas/src/pipeline/OASDereferenceStage.ts
@@ -1,6 +1,6 @@
 import SwaggerParser from "@apidevtools/swagger-parser";
-import { OASStageContext } from "./OASStageContext";
-import { PipelineStage } from "./PipelineExecutor";
+import type { OASStageContext } from "./OASStageContext";
+import type { PipelineStage } from "./PipelineExecutor";
 
 /**
  * OAS 문서의 모든 $ref를 평탄화함

--- a/packages/patchlogr-oas/src/pipeline/OASStageContext.ts
+++ b/packages/patchlogr-oas/src/pipeline/OASStageContext.ts
@@ -1,5 +1,5 @@
-import { CanonicalSpec } from "@patchlogr/types";
-import { OpenAPI } from "openapi-types";
+import type { CanonicalSpec } from "@patchlogr/types";
+import type { OpenAPI } from "openapi-types";
 
 export type OASStageInput = string | OpenAPI.Document;
 

--- a/packages/patchlogr-oas/src/pipeline/OASValidationStage.ts
+++ b/packages/patchlogr-oas/src/pipeline/OASValidationStage.ts
@@ -1,7 +1,7 @@
 import SwaggerParser from "@apidevtools/swagger-parser";
 
-import { PipelineStage } from "./PipelineExecutor";
-import { OASStageContext } from "./OASStageContext";
+import type { PipelineStage } from "./PipelineExecutor";
+import type { OASStageContext } from "./OASStageContext";
 import { getOASVersion } from "../utils/oasVersionUtils";
 
 /**

--- a/packages/patchlogr-oas/src/pipeline/__tests__/OASBundleStage.test.ts
+++ b/packages/patchlogr-oas/src/pipeline/__tests__/OASBundleStage.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { OASBundleStage } from "../OASBundleStage";
-import { OASStageContext } from "../OASStageContext";
+import type { OASStageContext } from "../OASStageContext";
 import path from "path";
-import { OpenAPIV3 } from "openapi-types";
+import type { OpenAPIV3 } from "openapi-types";
 
 describe("OASBundleStage", () => {
     test("should dereference external $ref correctly", async () => {

--- a/packages/patchlogr-oas/src/pipeline/__tests__/OASDereferenceStage.test.ts
+++ b/packages/patchlogr-oas/src/pipeline/__tests__/OASDereferenceStage.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { OASDereferenceStage } from "../OASDereferenceStage";
-import { OASStageContext } from "../OASStageContext";
+import type { OASStageContext } from "../OASStageContext";
 
 describe("OASDereferenceStage", () => {
     test("should throw an error if input.oas is missing", async () => {

--- a/packages/patchlogr-oas/src/pipeline/__tests__/OASValidationStage.test.ts
+++ b/packages/patchlogr-oas/src/pipeline/__tests__/OASValidationStage.test.ts
@@ -1,8 +1,8 @@
-import { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { describe, expect, test } from "vitest";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import { OASValidationStage } from "../OASValidationStage";
-import { OASStageContext } from "../OASStageContext";
+import type { OASStageContext } from "../OASStageContext";
 
 const oasFixtureV2: OpenAPIV2.Document = {
     swagger: "2.0",

--- a/packages/patchlogr-oas/src/pipeline/__tests__/PipelineExecutor.test.ts
+++ b/packages/patchlogr-oas/src/pipeline/__tests__/PipelineExecutor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vitest } from "vitest";
-import { PipelineExecutor, PipelineStage } from "../PipelineExecutor";
+import type { PipelineStage } from "../PipelineExecutor";
+import { PipelineExecutor } from "../PipelineExecutor";
 
 describe("PipelineExecutor", () => {
     test("should append stages correctly", () => {

--- a/packages/patchlogr-oas/src/preprocessOASDocument.ts
+++ b/packages/patchlogr-oas/src/preprocessOASDocument.ts
@@ -1,8 +1,11 @@
-import { OpenAPI } from "openapi-types";
+import type { OpenAPI } from "openapi-types";
 import { OASBundleStage } from "./pipeline/OASBundleStage";
 import { OASCanonicalizeStage } from "./pipeline/OASCanonicalizeStage";
 import { OASDereferenceStage } from "./pipeline/OASDereferenceStage";
-import { OASStageOptions, OASStageContext } from "./pipeline/OASStageContext";
+import type {
+    OASStageOptions,
+    OASStageContext,
+} from "./pipeline/OASStageContext";
 import { OASValidationStage } from "./pipeline/OASValidationStage";
 import { PipelineExecutor } from "./pipeline/PipelineExecutor";
 

--- a/packages/patchlogr-oas/src/preprocessOASDocument.ts
+++ b/packages/patchlogr-oas/src/preprocessOASDocument.ts
@@ -1,0 +1,24 @@
+import { OpenAPI } from "openapi-types";
+import { OASBundleStage } from "./pipeline/OASBundleStage";
+import { OASCanonicalizeStage } from "./pipeline/OASCanonicalizeStage";
+import { OASDereferenceStage } from "./pipeline/OASDereferenceStage";
+import { OASStageOptions, OASStageContext } from "./pipeline/OASStageContext";
+import { OASValidationStage } from "./pipeline/OASValidationStage";
+import { PipelineExecutor } from "./pipeline/PipelineExecutor";
+
+export function preprocessOASDocument(
+    doc: OpenAPI.Document,
+    options: OASStageOptions = {},
+) {
+    const pipelineExecutor = new PipelineExecutor<OASStageContext>();
+
+    pipelineExecutor.add(new OASBundleStage());
+    pipelineExecutor.add(new OASValidationStage());
+    pipelineExecutor.add(new OASDereferenceStage());
+    pipelineExecutor.add(new OASCanonicalizeStage());
+
+    return pipelineExecutor.run({
+        source: doc,
+        options,
+    });
+}

--- a/packages/patchlogr-oas/src/utils/__tests__/toCanonicalSchema.test.ts
+++ b/packages/patchlogr-oas/src/utils/__tests__/toCanonicalSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { toCanonicalSchema } from "../toCanonicalSchema";
-import { OpenAPISchemaObjectWithItems } from "../../guards/schemaGuards";
+import type { OpenAPISchemaObjectWithItems } from "../../guards/schemaGuards";
 
 describe("toCanonicalSchema", () => {
     test("should normalize simple schema", () => {

--- a/packages/patchlogr-oas/src/utils/__tests__/toCanonicalSchemaV2.test.ts
+++ b/packages/patchlogr-oas/src/utils/__tests__/toCanonicalSchemaV2.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { toCanonicalSchemaV2 } from "../toCanonicalSchemaV2";
-import { OpenAPIV2 } from "openapi-types";
+import type { OpenAPIV2 } from "openapi-types";
 
 describe("toCanonicalSchemaV2", () => {
     it("should convert a simple string schema", () => {

--- a/packages/patchlogr-oas/src/utils/__tests__/toCanonicalSchemaV3.test.ts
+++ b/packages/patchlogr-oas/src/utils/__tests__/toCanonicalSchemaV3.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { toCanonicalSchemaV3 } from "../toCanonicalSchemaV3";
-import { OpenAPIV3 } from "openapi-types";
+import type { OpenAPIV3 } from "openapi-types";
 
 describe("toCanonicalSchemaV3", () => {
     it("should convert a simple string schema", () => {

--- a/packages/patchlogr-oas/src/utils/oasVersionUtils.ts
+++ b/packages/patchlogr-oas/src/utils/oasVersionUtils.ts
@@ -1,4 +1,4 @@
-import { OpenAPI, OpenAPIV2, OpenAPIV3 } from "openapi-types";
+import type { OpenAPI, OpenAPIV2, OpenAPIV3 } from "openapi-types";
 
 export function getOASVersion(doc: OpenAPI.Document): string | undefined {
     if (isOpenAPIV3(doc)) {

--- a/packages/patchlogr-oas/src/utils/toCanonicalSchema.ts
+++ b/packages/patchlogr-oas/src/utils/toCanonicalSchema.ts
@@ -1,10 +1,7 @@
-import { CanonicalSchema } from "@patchlogr/types";
-import { OpenAPIV2, OpenAPIV3 } from "openapi-types";
-import {
-    isSchemaObject,
-    OpenAPISchemaObject,
-    isOpenAPIV3Schema,
-} from "../guards/schemaGuards";
+import { type CanonicalSchema } from "@patchlogr/types";
+import type { OpenAPIV2, OpenAPIV3 } from "openapi-types";
+import type { OpenAPISchemaObject } from "../guards/schemaGuards";
+import { isSchemaObject, isOpenAPIV3Schema } from "../guards/schemaGuards";
 import { toCanonicalSchemaV2 } from "./toCanonicalSchemaV2";
 import { toCanonicalSchemaV3 } from "./toCanonicalSchemaV3";
 

--- a/packages/patchlogr-oas/src/utils/toCanonicalSchemaV2.ts
+++ b/packages/patchlogr-oas/src/utils/toCanonicalSchemaV2.ts
@@ -1,9 +1,7 @@
-import { CanonicalSchema } from "@patchlogr/types";
-import { OpenAPIV2 } from "openapi-types";
-import {
-    isSchemaObject,
-    OpenAPISchemaObjectWithCommonProps,
-} from "../guards/schemaGuards";
+import { type CanonicalSchema } from "@patchlogr/types";
+import { type OpenAPIV2 } from "openapi-types";
+import type { OpenAPISchemaObjectWithCommonProps } from "../guards/schemaGuards";
+import { isSchemaObject } from "../guards/schemaGuards";
 
 export function toCanonicalSchemaV2(
     schema: OpenAPIV2.SchemaObject | undefined,

--- a/packages/patchlogr-oas/src/utils/toCanonicalSchemaV3.ts
+++ b/packages/patchlogr-oas/src/utils/toCanonicalSchemaV3.ts
@@ -1,9 +1,7 @@
-import { CanonicalSchema } from "@patchlogr/types";
-import { OpenAPIV3 } from "openapi-types";
-import {
-    isSchemaObject,
-    OpenAPISchemaObjectWithCommonProps,
-} from "../guards/schemaGuards";
+import { type CanonicalSchema } from "@patchlogr/types";
+import { type OpenAPIV3 } from "openapi-types";
+import type { OpenAPISchemaObjectWithCommonProps } from "../guards/schemaGuards";
+import { isSchemaObject } from "../guards/schemaGuards";
 
 export function toCanonicalSchemaV3(
     schema: OpenAPIV3.SchemaObject | undefined,

--- a/packages/patchlogr-oas/tsconfig.json
+++ b/packages/patchlogr-oas/tsconfig.json
@@ -1,15 +1,15 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "nodenext",
         "outDir": "dist",
         "rootDir": "src",
 
+        // build .d.ts
         "declaration": true,
         "declarationMap": true,
         "emitDeclarationOnly": false,
 
-        "lib": ["esnext"]
+        "noEmit": false
     },
     "include": ["src"]
 }

--- a/packages/patchlogr-types/package.json
+++ b/packages/patchlogr-types/package.json
@@ -11,6 +11,7 @@
     "scripts": {
         "build": "tsc",
         "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {

--- a/packages/patchlogr-types/tsconfig.json
+++ b/packages/patchlogr-types/tsconfig.json
@@ -1,18 +1,16 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "nodenext",
         "outDir": "dist",
         "rootDir": "src",
 
+        // build .d.ts only
         "declaration": true,
         "declarationMap": true,
         "emitDeclarationOnly": true,
 
-        "skipLibCheck": false,
-        "noEmit": false,
-
-        "lib": ["esnext"]
+        // override base settings
+        "noEmit": false
     },
     "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,12 @@
 {
     "compilerOptions": {
-        "target": "ES2020",
-        "lib": ["ES2020"],
+        // node20+ apis & syntax
+        "target": "ES2022",
+        "lib": ["ES2022"],
+
+        // node esm, cjs compat
+        "module": "NodeNext",
         "moduleResolution": "NodeNext",
-        "resolveJsonModule": true,
-        "allowSyntheticDefaultImports": true,
 
         "strict": true,
         "noImplicitAny": false,
@@ -13,10 +15,13 @@
         "useUnknownInCatchVariables": true,
         "forceConsistentCasingInFileNames": true,
 
+        "resolveJsonModule": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+
+        // overrides
         "skipLibCheck": true,
         "isolatedModules": true,
-        "noEmit": true,
-
-        "esModuleInterop": true
+        "noEmit": true
     }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,10 @@
             "inputs": ["src/**", "package.json"],
             "outputs": []
         },
+        "lint:fix": {
+            "inputs": ["src/**", "package.json"],
+            "outputs": []
+        },
         "clean": {
             "cache": false,
             "outputs": []

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,10 +405,14 @@ __metadata:
   resolution: "@patchlogr/cli@workspace:packages/patchlogr-cli"
   dependencies:
     "@patchlogr/core": "workspace:*"
+    "@patchlogr/oas": "workspace:*"
     "@types/node": "npm:24"
+    commander: "npm:^14.0.2"
     esbuild: "npm:^0.27.2"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.0.16"
+  bin:
+    patchlogr: ./dist/index.js
   languageName: unknown
   linkType: soft
 
@@ -432,6 +436,7 @@ __metadata:
     "@apidevtools/swagger-parser": "npm:^12.1.0"
     "@patchlogr/types": "workspace:*"
     "@types/node": "npm:24"
+    esbuild: "npm:^0.27.2"
     openapi-types: "npm:^12.1.3"
     vitest: "npm:^4.0.16"
   languageName: unknown
@@ -1082,6 +1087,13 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.2":
+  version: 14.0.2
+  resolution: "commander@npm:14.0.2"
+  checksum: 10c0/245abd1349dbad5414cb6517b7b5c584895c02c4f7836ff5395f301192b8566f9796c82d7bd6c92d07eba8775fe4df86602fca5d86d8d10bcc2aded1e21c2aeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📎 Related issues

- resolve #7

## 📦 Scope

<!--이번 변경으로 영향을 받는 패키지를 선택해주세요.-->

- [ ] @patchlogr/core
- [x] @patchlogr/cli
- [ ] @patchlogr/inspector
- [x] @patchlogr/oas
- [x] @patchlogr/types
- [ ] docs, examples
- [ ] tests
- [x] ci / cd / infra
- [ ] other (아래에 명시)

## 📌 Summary

<!-- 이 PR에서 무엇이 바뀌었는지 한 줄 요약 -->
- tsconfig 빌드 target, module resolution 설정 통일 및 일관성에 어긋나는 부분 수정
- esbuild 및 package json 빌드 스크립트 작성
- 배럴파일 규칙 통일

## 🧠 Context

- target es2022 (node20+ 타깃으로 설정),  lib es2022
- module : nodenext (esm, cjs compat 한 node 타깃으로 설정)
- moduleResolution : nodenext (module 과 통일)
- esModuleInterop, allowSyntheticDefaultImports, resolveJsonModule 설정으로 json 모듈 및 esm 에서 cjs 의 default import 를 허용하도록 설정

## ⚠️ Impact
-   [ ] No Breaking Changes
-   [ ] Breaking Change
-   [ ] Versioning 영향 있음 (major / minor / patch)
-   [x] 내부 리팩토링만 포함

## ✅ Checklist

- [x] 요구사항 명세 충족
- [ ] 테스트 추가 / 수정
- [x] deterministic output 확인
