### PR TITLE
diffSpec 시 변경된 hash값만 리턴하도록 수정

### DIFF
--- a/packages/patchlogr-core/src/diff/__tests__/diffChildNodes.test.ts
+++ b/packages/patchlogr-core/src/diff/__tests__/diffChildNodes.test.ts
@@ -62,22 +62,6 @@ describe("diffChildNodes", () => {
                 baseNodeType: "node",
             });
         });
-
-        test("removed leaf의 value가 있으면 baseValue 포함", () => {
-            const removedChild = createLeafNode("item", "hash-removed", {
-                data: "value",
-            });
-            const base = createNode("root", "hash-old", [removedChild]);
-            const head = createNode("root", "hash-new", []);
-
-            if (base.type !== "node" || head.type !== "node") {
-                throw new Error("Expected node types");
-            }
-
-            const result = diffChildNodes(base, head, ["root"]);
-
-            expect(result.changes[0]?.baseValue).toEqual({ data: "value" });
-        });
     });
 
     describe("added detection (head에만 존재)", () => {
@@ -138,22 +122,6 @@ describe("diffChildNodes", () => {
                 key: "subtree",
                 headNodeType: "node",
             });
-        });
-
-        test("added leaf의 value가 있으면 headValue 포함", () => {
-            const addedChild = createLeafNode("item", "hash-added", {
-                data: "value",
-            });
-            const base = createNode("root", "hash-old", []);
-            const head = createNode("root", "hash-new", [addedChild]);
-
-            if (base.type !== "node" || head.type !== "node") {
-                throw new Error("Expected node types");
-            }
-
-            const result = diffChildNodes(base, head, ["root"]);
-
-            expect(result.changes[0]?.headValue).toEqual({ data: "value" });
         });
     });
 

--- a/packages/patchlogr-core/src/diff/__tests__/diffLeafNodes.test.ts
+++ b/packages/patchlogr-core/src/diff/__tests__/diffLeafNodes.test.ts
@@ -16,40 +16,6 @@ describe("diffLeafNodes", () => {
         expect(result.path).toEqual(["root", "user"]);
     });
 
-    test("value가 있는 경우 baseValue, headValue 포함", () => {
-        const baseValue = { email: "old@test.com" };
-        const headValue = { email: "new@test.com" };
-        const base = createLeafNode("config", "hash-v1", baseValue);
-        const head = createLeafNode("config", "hash-v2", headValue);
-
-        const result = diffLeafNodes(base, head, ["root", "config"]);
-
-        expect(result.baseValue).toEqual(baseValue);
-        expect(result.headValue).toEqual(headValue);
-    });
-
-    test("base에만 value가 있는 경우 baseValue만 포함", () => {
-        const baseValue = { data: "old" };
-        const base = createLeafNode("item", "hash-old", baseValue);
-        const head = createLeafNode("item", "hash-new", undefined);
-
-        const result = diffLeafNodes(base, head, ["root", "item"]);
-
-        expect(result.baseValue).toEqual(baseValue);
-        expect(result.headValue).toBeUndefined();
-    });
-
-    test("head에만 value가 있는 경우 headValue만 포함", () => {
-        const headValue = { data: "new" };
-        const base = createLeafNode("item", "hash-old", undefined);
-        const head = createLeafNode("item", "hash-new", headValue);
-
-        const result = diffLeafNodes(base, head, ["root", "item"]);
-
-        expect(result.baseValue).toBeUndefined();
-        expect(result.headValue).toEqual(headValue);
-    });
-
     test("path는 전달받은 그대로 사용", () => {
         const base = createLeafNode("endpoint", "hash-a", { v: 1 });
         const head = createLeafNode("endpoint", "hash-b", { v: 2 });

--- a/packages/patchlogr-core/src/diff/__tests__/diffNode.test.ts
+++ b/packages/patchlogr-core/src/diff/__tests__/diffNode.test.ts
@@ -31,23 +31,6 @@ describe("diffNode", () => {
         });
     });
 
-    test("둘 다 leaf인데 key가 동일하고 hash가 다른 경우 modified 1건 + value 포함", () => {
-        const baseValue = { email: "old@test.com" };
-        const headValue = { email: "new@test.com" };
-        const base = createLeafNode("config", "hash-v1", baseValue);
-        const head = createLeafNode("config", "hash-v2", headValue);
-
-        const result = diffNode(base, head);
-
-        expect(result.changes).toHaveLength(1);
-        expect(result.changes[0]).toMatchObject({
-            type: "modified",
-            key: "config",
-            baseValue,
-            headValue,
-        });
-    });
-
     test("base와 head가 둘 다 node이고 hash가 다른 경우 children을 key 기준으로 비교", () => {
         const baseChild = createLeafNode("child1", "hash-child-old", {
             v: 1,
@@ -227,7 +210,7 @@ describe("diffNode", () => {
         });
     });
 
-    test("D13: base가 leaf이고 head가 node인 경우 type_changed 1건", () => {
+    test("base가 leaf이고 head가 node인 경우 type_changed 1건", () => {
         const child = createLeafNode("child", "hash-child", { v: 1 });
         const base = createLeafNode<string, unknown>("target", "hash-leaf", {
             v: "simple",
@@ -250,7 +233,7 @@ describe("diffNode", () => {
     });
 });
 
-describe("Path / key 기록 규칙", () => {
+describe("path / key", () => {
     test("모든 change에는 path가 있어야 함 (root부터 변화 노드까지)", () => {
         const baseLeaf = createLeafNode("endpoint", "hash-old", {
             method: "GET",

--- a/packages/patchlogr-core/src/diff/__tests__/diffTypeChange.test.ts
+++ b/packages/patchlogr-core/src/diff/__tests__/diffTypeChange.test.ts
@@ -39,59 +39,6 @@ describe("diffTypeChange", () => {
         expect(result.headNodeType).toBe("node");
     });
 
-    test("base가 leaf일 때 baseValue 포함", () => {
-        const baseValue = { data: "original" };
-        const base = createLeafNode<string, unknown>(
-            "item",
-            "hash-leaf",
-            baseValue,
-        );
-        const head = createNode<string, unknown>("item", "hash-node", []);
-
-        const result = diffTypeChange(base, head, ["root", "item"]);
-
-        expect(result.baseValue).toEqual(baseValue);
-        expect(result.headValue).toBeUndefined();
-    });
-
-    test("head가 leaf일 때 headValue 포함", () => {
-        const headValue = { data: "collapsed" };
-        const base = createNode<string, unknown>("item", "hash-node", []);
-        const head = createLeafNode<string, unknown>(
-            "item",
-            "hash-leaf",
-            headValue,
-        );
-
-        const result = diffTypeChange(base, head, ["root", "item"]);
-
-        expect(result.baseValue).toBeUndefined();
-        expect(result.headValue).toEqual(headValue);
-    });
-
-    test("양쪽 모두 leaf에서 다른 leaf일 때", () => {
-        const baseValue = { v: 1 };
-        const headValue = { v: 2 };
-        const base = createLeafNode<string, unknown>(
-            "item",
-            "hash-old",
-            baseValue,
-        );
-        const head = createLeafNode<string, unknown>(
-            "item",
-            "hash-new",
-            headValue,
-        );
-
-        const result = diffTypeChange(base, head, ["root", "item"]);
-
-        expect(result.type).toBe("type_changed");
-        expect(result.baseNodeType).toBe("leaf");
-        expect(result.headNodeType).toBe("leaf");
-        expect(result.baseValue).toEqual(baseValue);
-        expect(result.headValue).toEqual(headValue);
-    });
-
     test("path는 전달받은 그대로 사용", () => {
         const base = createNode<string, unknown>("target", "hash-node", []);
         const head = createLeafNode<string, unknown>("target", "hash-leaf", {});

--- a/packages/patchlogr-core/src/diff/diffChangeSet.ts
+++ b/packages/patchlogr-core/src/diff/diffChangeSet.ts
@@ -2,22 +2,19 @@ export type ChangeType = "added" | "removed" | "modified" | "type_changed";
 
 export type ChangePath<K> = K[];
 
-export type SpecChange<K = string, V = unknown> = {
+export type SpecChange<K = string> = {
     type: ChangeType;
     path: ChangePath<K>;
     key: K;
     baseHash?: string;
     headHash?: string;
 
-    baseValue?: V;
-    headValue?: V;
-
     baseNodeType?: "node" | "leaf";
     headNodeType?: "node" | "leaf";
 };
 
-export type SpecChangeSet<K = string, V = unknown> = {
+export type SpecChangeSet<K = string> = {
     baseHash: string;
     headHash: string;
-    changes: SpecChange<K, V>[];
+    changes: SpecChange<K>[];
 };

--- a/packages/patchlogr-core/src/diff/diffChildNodes.ts
+++ b/packages/patchlogr-core/src/diff/diffChildNodes.ts
@@ -8,21 +8,21 @@ import type { ChangePath, SpecChange } from "./diffChangeSet.js";
  * @param head 비교 대상 node
  * @param path 현재 경로 (base.key 포함)
  */
-export function diffChildNodes<K, V>(
-    base: HashNode<K, V>,
-    head: HashNode<K, V>,
+export function diffChildNodes<K>(
+    base: HashNode<K>,
+    head: HashNode<K>,
     path: ChangePath<K>,
 ): {
-    changes: SpecChange<K, V>[];
+    changes: SpecChange<K>[];
     modifiedPairs: Array<{
-        base: HashNode<K, V>;
-        head: HashNode<K, V>;
+        base: HashNode<K>;
+        head: HashNode<K>;
     }>;
 } {
-    const changes: SpecChange<K, V>[] = [];
+    const changes: SpecChange<K>[] = [];
     const modifiedPairs: Array<{
-        base: HashNode<K, V>;
-        head: HashNode<K, V>;
+        base: HashNode<K>;
+        head: HashNode<K>;
     }> = [];
 
     const baseChildMap = new Map(
@@ -36,18 +36,13 @@ export function diffChildNodes<K, V>(
     for (const [key, baseChild] of baseChildMap) {
         if (!headChildMap.has(key)) {
             const childPath = [...path, key];
-            const change: SpecChange<K, V> = {
+            changes.push({
                 type: "removed",
                 path: childPath,
                 key: key,
                 baseHash: baseChild.hash,
                 baseNodeType: baseChild.type,
-            };
-
-            if (baseChild.type === "leaf" && baseChild.value !== undefined) {
-                change.baseValue = baseChild.value;
-            }
-            changes.push(change);
+            });
         }
     }
 
@@ -55,18 +50,13 @@ export function diffChildNodes<K, V>(
     for (const [key, headChild] of headChildMap) {
         if (!baseChildMap.has(key)) {
             const childPath = [...path, key];
-            const change: SpecChange<K, V> = {
+            changes.push({
                 type: "added",
                 path: childPath,
                 key: key,
                 headHash: headChild.hash,
                 headNodeType: headChild.type,
-            };
-
-            if (headChild.type === "leaf" && headChild.value !== undefined) {
-                change.headValue = headChild.value;
-            }
-            changes.push(change);
+            });
         }
     }
 

--- a/packages/patchlogr-core/src/diff/diffLeafNodes.ts
+++ b/packages/patchlogr-core/src/diff/diffLeafNodes.ts
@@ -7,25 +7,16 @@ import type { ChangePath, SpecChange } from "./diffChangeSet.js";
  * @param head 비교 대상 leaf 노드
  * @param path 현재 경로 (base.key 포함)
  */
-export function diffLeafNodes<K, V>(
-    base: HashNode<K, V>,
-    head: HashNode<K, V>,
+export function diffLeafNodes<K>(
+    base: HashNode<K>,
+    head: HashNode<K>,
     path: ChangePath<K>,
-): SpecChange<K, V> {
-    const change: SpecChange<K, V> = {
+): SpecChange<K> {
+    return {
         type: "modified",
         path,
         key: base.key,
         baseHash: base.hash,
         headHash: head.hash,
     };
-
-    if (base.value !== undefined) {
-        change.baseValue = base.value;
-    }
-    if (head.value !== undefined) {
-        change.headValue = head.value;
-    }
-
-    return change;
 }

--- a/packages/patchlogr-core/src/diff/diffNode.ts
+++ b/packages/patchlogr-core/src/diff/diffNode.ts
@@ -4,12 +4,12 @@ import { diffLeafNodes } from "./diffLeafNodes";
 import { diffTypeChange } from "./diffTypeChange";
 import { diffChildNodes } from "./diffChildNodes";
 
-export function diffNode<K, V>(
-    base: HashNode<K, V>,
-    head: HashNode<K, V>,
+export function diffNode<K>(
+    base: HashNode<K>,
+    head: HashNode<K>,
     path: ChangePath<K> = [],
-): SpecChangeSet<K, V> {
-    const changes: SpecChange<K, V>[] = [];
+): SpecChangeSet<K> {
+    const changes: SpecChange<K>[] = [];
     const currentPath = [...path, base.key];
 
     if (base.hash === head.hash) {

--- a/packages/patchlogr-core/src/diff/diffSpec.ts
+++ b/packages/patchlogr-core/src/diff/diffSpec.ts
@@ -2,9 +2,9 @@ import type { PartitionedSpec } from "../partition/index.js";
 import type { SpecChangeSet } from "./diffChangeSet.js";
 import { diffNode } from "./diffNode.js";
 
-export function diffSpec<K extends string = string, V = unknown>(
-    base: PartitionedSpec<K, V>,
-    head: PartitionedSpec<K, V>,
-): SpecChangeSet<K, V> {
+export function diffSpec<K extends string = string>(
+    base: PartitionedSpec<K>,
+    head: PartitionedSpec<K>,
+): SpecChangeSet<K> {
     return diffNode(base.root, head.root);
 }

--- a/packages/patchlogr-core/src/diff/diffTypeChange.ts
+++ b/packages/patchlogr-core/src/diff/diffTypeChange.ts
@@ -7,12 +7,12 @@ import type { ChangePath, SpecChange } from "./diffChangeSet.js";
  * @param head 비교 대상 노드
  * @param path 현재 경로 (base.key 포함)
  */
-export function diffTypeChange<K, V>(
-    base: HashNode<K, V>,
-    head: HashNode<K, V>,
+export function diffTypeChange<K>(
+    base: HashNode<K>,
+    head: HashNode<K>,
     path: ChangePath<K>,
-): SpecChange<K, V> {
-    const change: SpecChange<K, V> = {
+): SpecChange<K> {
+    return {
         type: "type_changed",
         path,
         key: base.key,
@@ -21,13 +21,4 @@ export function diffTypeChange<K, V>(
         baseNodeType: base.type,
         headNodeType: head.type,
     };
-
-    if (base.type === "leaf" && base.value !== undefined) {
-        change.baseValue = base.value;
-    }
-    if (head.type === "leaf" && head.value !== undefined) {
-        change.headValue = head.value;
-    }
-
-    return change;
 }


### PR DESCRIPTION
## 📎 Related issues

- resolve #22

## 📦 Scope

<!--이번 변경으로 영향을 받는 패키지를 선택해주세요.-->

- [x] @patchlogr/core
- [ ] @patchlogr/cli
- [ ] @patchlogr/oas
- [ ] @patchlogr/inspector
- [ ] @patchlogr/types
- [ ] docs, examples
- [ ] tests
- [ ] ci / cd / infra
- [ ] other (아래에 명시)

## 📌 Summary

<!-- 이 PR에서 무엇이 바뀌었는지 한 줄 요약 -->
- diffSpec 시 변경된 hash값만 리턴하도록 수정

## 🧠 Context

<!-- 왜 이 변경이 필요한지 -->
- #23 에서 HashObject 를 따로 리턴함에 따라 spec 비교에서는 변경된 해시값만 리턴하도록 수정
- 추후, 해당 해시값을 외부 storage 에서 찾아 비교하도록 변경

## ⚠️ Impact

- [ ] No Breaking Changes
- [x] Breaking Change
- [x] Versioning 영향 있음 (major / minor / patch)
- [ ] 내부 리팩토링만 포함

## ✅ Checklist

- [x] 요구사항 명세 충족
- [x] 테스트 추가 / 수정
- [x] deterministic output 확인
