### PR TITLE
@patchlogr/cli 패키지를 위한 diff 커맨드 추가

### DIFF
--- a/packages/patchlogr-adapter-oas/src/oas-v2/toCanonicalSchema.ts
+++ b/packages/patchlogr-adapter-oas/src/oas-v2/toCanonicalSchema.ts
@@ -1,6 +1,5 @@
 import { type CanonicalSchema } from "@patchlogr/types";
 import { type OpenAPIV2 } from "openapi-types";
-import type { OpenAPISchemaObjectWithCommonProps } from "../oas-common/schemaGuards";
 import { isSchemaObject } from "../oas-common/schemaGuards";
 
 export function toCanonicalSchema(

--- a/packages/patchlogr-cli/src/commands/canonicalize.ts
+++ b/packages/patchlogr-cli/src/commands/canonicalize.ts
@@ -11,7 +11,11 @@ export type CanonicalizeOptions = OASStageOptions & {
 
 export const canonicalizeCommand = new Command("canonicalize")
     .argument("<api-docs>", "Path to the OpenAPI specification file")
-    .option("--skipValidation", "Skip validation of the OpenAPI specification")
+    .option(
+        "--skipValidation",
+        "Skip validation of the OpenAPI specification",
+        true,
+    )
     .option(
         "-o, --output <file>",
         "Write result to file instead of stdout (default: stdout)",

--- a/packages/patchlogr-cli/src/commands/diff.ts
+++ b/packages/patchlogr-cli/src/commands/diff.ts
@@ -1,0 +1,88 @@
+import { preprocessOASDocument } from "@patchlogr/adapter-oas";
+import {
+    detectVersionBump,
+    diffSpec,
+    partitionByMethod,
+    partitionByTag,
+    type PartitionedSpec,
+} from "@patchlogr/core";
+
+import { Command } from "commander";
+import { OpenAPI } from "openapi-types";
+
+import fs from "fs/promises";
+
+export type DiffOptions = {
+    partition: "tag" | "method";
+    output?: "stdout" | string;
+    skipValidation: boolean;
+};
+
+export const diffCommand = new Command("diff")
+    .description("Diff two OpenAPI Specification files")
+    .argument("<base>", "Base OpenAPI Specification file")
+    .argument("<head>", "Head OpenAPI Specification file")
+    .option("-o, --output <file>", "Output file")
+    .option("--skipValidation", "Skip validation", true)
+    .option("-p, --partition <partition>", "Partition Strategy", "tag")
+    .action(diffAction);
+
+export async function diffAction(
+    basePath: OpenAPI.Document,
+    headPath: OpenAPI.Document,
+    options: DiffOptions,
+) {
+    const preprocessedBase = await preprocessOASDocument(basePath, {
+        skipValidation: options.skipValidation,
+    });
+    const preprocessedHead = await preprocessOASDocument(headPath, {
+        skipValidation: options.skipValidation,
+    });
+
+    const baseCanonicalSpec = preprocessedBase.canonicalSpec;
+    const headCanonicalSpec = preprocessedHead.canonicalSpec;
+
+    if (!baseCanonicalSpec || !headCanonicalSpec) {
+        throw new Error("Failed to preprocess OpenAPI Specification files");
+    }
+
+    let partitionedBase: PartitionedSpec;
+    let partitionedHead: PartitionedSpec;
+
+    switch (options.partition) {
+        case "method":
+            partitionedBase = partitionByMethod(baseCanonicalSpec);
+            partitionedHead = partitionByMethod(headCanonicalSpec);
+            break;
+        case "tag":
+        default:
+            partitionedBase = partitionByTag(baseCanonicalSpec);
+            partitionedHead = partitionByTag(headCanonicalSpec);
+            break;
+    }
+
+    const specChangeSet = diffSpec(partitionedBase, partitionedHead);
+    const versionBump = detectVersionBump(specChangeSet);
+
+    if (options.output === "stdout" || options.output === undefined) {
+        console.log(JSON.stringify(specChangeSet, null, 2));
+        console.log(JSON.stringify(versionBump, null, 2));
+    } else {
+        try {
+            await fs.writeFile(
+                options.output.concat(".json"),
+                JSON.stringify(specChangeSet, null, 2),
+                "utf-8",
+            );
+            await fs.writeFile(
+                options.output.concat(".version.json"),
+                JSON.stringify(versionBump, null, 2),
+                "utf-8",
+            );
+        } catch (error) {
+            throw new Error(`Failed to write to file ${options.output}:`, {
+                cause: error,
+            });
+        }
+    }
+}

--- a/packages/patchlogr-cli/src/commands/diff.ts
+++ b/packages/patchlogr-cli/src/commands/diff.ts
@@ -64,19 +64,15 @@ export async function diffAction(
     const specChangeSet = diffSpec(partitionedBase, partitionedHead);
     const versionBump = detectVersionBump(specChangeSet);
 
+    const result = { specChangeSet, versionBump };
+
     if (options.output === "stdout" || options.output === undefined) {
-        console.log(JSON.stringify(specChangeSet, null, 2));
-        console.log(JSON.stringify(versionBump, null, 2));
+        console.log(JSON.stringify(result, null, 2));
     } else {
         try {
             await fs.writeFile(
-                options.output.concat(".json"),
-                JSON.stringify(specChangeSet, null, 2),
-                "utf-8",
-            );
-            await fs.writeFile(
-                options.output.concat(".version.json"),
-                JSON.stringify(versionBump, null, 2),
+                options.output,
+                JSON.stringify(result, null, 2),
                 "utf-8",
             );
         } catch (error) {

--- a/packages/patchlogr-cli/src/commands/diff.ts
+++ b/packages/patchlogr-cli/src/commands/diff.ts
@@ -8,7 +8,7 @@ import {
 } from "@patchlogr/core";
 
 import { Command } from "commander";
-import { OpenAPI } from "openapi-types";
+import { type OpenAPI } from "openapi-types";
 
 import fs from "fs/promises";
 

--- a/packages/patchlogr-cli/src/createCLI.ts
+++ b/packages/patchlogr-cli/src/createCLI.ts
@@ -3,6 +3,7 @@ import pkg from "../package.json";
 
 import { helpCommand } from "./commands/help";
 import { canonicalizeCommand } from "./commands/canonicalize";
+import { diffCommand } from "./commands/diff";
 
 export function createCLI() {
     return new Command()
@@ -10,5 +11,6 @@ export function createCLI() {
         .version(pkg.version)
         .description("PatchlogrCLI : changelogs from openapi specs")
         .addCommand(helpCommand)
-        .addCommand(canonicalizeCommand);
+        .addCommand(canonicalizeCommand)
+        .addCommand(diffCommand);
 }

--- a/packages/patchlogr-core/tsconfig.json
+++ b/packages/patchlogr-core/tsconfig.json
@@ -7,7 +7,9 @@
 
         "declaration": true,
         "declarationMap": true,
-        "emitDeclarationOnly": false
+        "emitDeclarationOnly": false,
+
+        "noEmit": false
     },
     "include": ["src"]
 }


### PR DESCRIPTION
## 📎 Related issues

- resolve #29

## 📦 Scope

<!--이번 변경으로 영향을 받는 패키지를 선택해주세요.-->

- [x] @patchlogr/core
- [x] @patchlogr/cli
- [ ] @patchlogr/oas
- [ ] @patchlogr/inspector
- [ ] @patchlogr/types
- [ ] docs, examples
- [ ] tests
- [ ] ci / cd / infra
- [ ] other (아래에 명시)

## 📌 Summary

<!-- 이 PR에서 무엇이 바뀌었는지 한 줄 요약 -->
- @patchlogr/core 에서 noEmit 으로 인해 d.ts 빌드 안되는 현상 수정
- diffCommand 구현 (preprocess -> partition -> diff)

## ⚠️ Impact

- [ ] No Breaking Changes
- [x] Breaking Change
- [x] Versioning 영향 있음 (major / minor / patch)
- [ ] 내부 리팩토링만 포함

## ✅ Checklist

- [x] 요구사항 명세 충족
- [ ] 테스트 추가 / 수정
- [x] deterministic output 확인
